### PR TITLE
Feature/fix strange error

### DIFF
--- a/src/answer-checker.coffee
+++ b/src/answer-checker.coffee
@@ -4,9 +4,9 @@
 # @module answer-checker
 
 FuzzySet = require 'fuzzyset.js'
-  
+
 goodConfidence = 0.65
-  
+
 # check if the guess is valid for the given answer
 # this calls FuzzySet on every consecutive combination of words from the guess
 # by https://github.com/natgaertner
@@ -19,13 +19,12 @@ module.exports = (guess, answer) ->
       match[0][0] # return the confidence level
   )
   return result.maxScore >= goodConfidence
-  
+
 # return element and keyfunc result for the element for which keyfunc returns the highest value
 keymax = (set, keyfunc) ->
   maxElement = null
   maxScore = 0
-  for idx of set
-    element = set[idx]
+  for element in set
     score = keyfunc(element)
     if score > maxScore
       maxElement = element
@@ -34,7 +33,7 @@ keymax = (set, keyfunc) ->
     maxElement: maxElement
     maxScore: maxScore
   }
-  
+
 # ['thin', 'crust', 'pizza'] => ['thin', 'crust', 'pizza', 'thin crust', 'crust pizza', 'thin crust pizza']
 pseudoPowerSet = (words) ->
   set = []

--- a/src/trivia-game.coffee
+++ b/src/trivia-game.coffee
@@ -69,9 +69,9 @@ class Game
       checkGuess = guess.toLowerCase()
       # remove html entities (slack's adapter sends & as &amp; now)
       checkGuess = checkGuess.replace /&.{0,}?;/, ""
-      # remove all punctuation and spaces, and see if the answer is in the guess.
-      checkGuess = checkGuess.replace /[\\'"\.,-\/#!$%\^&\*;:{}=\-_`~()\s]/g, ""
-      checkAnswer = @currentQ.validAnswer.toLowerCase().replace /[\\'"\.,-\/#!$%\^&\*;:{}=\-_`~()\s]/g, ""
+      # remove all punctuation and see if the answer is in the guess.
+      checkGuess = checkGuess.replace /[\\'"\.,-\/#!$%\^&\*;:{}=\-_`~()]/g, ""
+      checkAnswer = @currentQ.validAnswer.toLowerCase().replace /[\\'"\.,-\/#!$%\^&\*;:{}=\-_`~()]/g, ""
       checkAnswer = checkAnswer.replace /^(a(n?)|the)/g, ""
       if AnswerChecker(checkGuess, checkAnswer)
         resp.reply "YOU ARE CORRECT!!1!!!111!! The answer is #{@currentQ.answer}"


### PR DESCRIPTION
The iterator in AnswerChecker's `keymax` function was iterating over a function. I'm not 100% sure exactly what caused a function to be inserted into the set, i'm suspecting some kind of index-accesses-memory issue. Changing from a "x of y" iteration strategy to the "x in y" iteration strategy fixes the issue. 

I also removed the bit of regex that removes all whitespace from the answer. `powerset` creates its set by splitting on spaces, so it was only ever given a single word. I'm not sure if this was an important bit of functionality, but the game still works with the spaces and `powerset` is able to contribute! 